### PR TITLE
Macos native support and build system

### DIFF
--- a/.github/workflows/cpp_build_and_release.yaml
+++ b/.github/workflows/cpp_build_and_release.yaml
@@ -1,0 +1,99 @@
+name: C++ Build and Release
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*'
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup MSBuild Path
+        uses: microsoft/setup-msbuild@v1.3.1
+
+      - name: Build Windows Project
+        run: msbuild vcxproj/gsla.vcxproj /p:Configuration=Release
+     
+      - name: Show build directory contents
+        run: |
+          dir vcxproj/Release
+    
+      - name: Create Windows Archive
+        run: |
+          $zipName = "gsla_win_${{ github.ref_name }}.zip"
+          Compress-Archive -Path README.md, vcxproj/Release/gsla.exe -DestinationPath $zipName
+        shell: pwsh
+    
+      - name: Cache Windows Build
+        uses: actions/cache@v4
+        with:
+          path: gsla_win_${{ github.ref_name }}.zip
+          key: ${{ runner.os }}-cache-${{ github.sha }}
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: brew install make
+
+      - name: Build Mac Project
+        run: make
+
+      - name: Create Mac Archive
+        run: |
+          zip gsla_mac_${{ github.ref_name }}.zip README.md gsla
+    
+      - name: Cache Mac Build
+        uses: actions/cache@v4
+        with:
+          path: gsla_mac_${{ github.ref_name }}.zip
+          key: ${{ runner.os }}-cache-${{ github.sha }}
+
+  create-release:
+    needs: [build-windows, build-macos]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-latest, windows-latest ]
+    steps:
+        ### WINDOWS ################
+      - name: Restore Windows Cache
+        if: matrix.os == 'windows-latest'
+        uses: actions/cache@v4
+        with:
+            path: gsla_win_${{ github.ref_name }}.zip
+            key: ${{ runner.os }}-cache-${{ github.sha }}
+      - name: Create GitHub Release w/Windows Files
+        if: matrix.os == 'windows-latest'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            gsla_win_${{ github.ref_name }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+        ### MACOS ##################
+      - name: Restore Mac Cache
+        if: matrix.os == 'macos-latest'
+        uses: actions/cache@v4
+        with:
+          path: gsla_mac_${{ github.ref_name }}.zip
+          key: ${{ runner.os }}-cache-${{ github.sha }}
+      - name: Create GitHub Release w/Windows Files
+        if: matrix.os == 'macos-latest'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            gsla_mac_${{ github.ref_name }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# Compiler and flags
+CC = clang++
+CXXFLAGS = -Wall -Wextra -I./source
+#CXXFLAGS = -std=c++17 -Wall -Wextra -I./source
+LDFLAGS =
+
+# Source and object files
+SRC = ./source/c2_file.cpp ./source/gsla_file.cpp ./source/lzb.cpp ./source/main.cpp
+OBJ = $(SRC:.cpp=.o)
+TARGET = gsla
+
+# Build configurations
+DEBUG_FLAGS = -g -D_DEBUG -D_CONSOLE
+RELEASE_FLAGS = -O2 -DNDEBUG -D_CONSOLE
+
+# Default build is Debug
+CONFIG ?= Debug
+
+ifeq ($(CONFIG),Debug)
+  CXXFLAGS += $(DEBUG_FLAGS)
+else ifeq ($(CONFIG),Release)
+  CXXFLAGS += $(RELEASE_FLAGS)
+else
+  $(error Invalid CONFIG value. Use 'Debug' or 'Release')
+endif
+
+# Default target
+all: $(TARGET)
+
+# Link the executable
+$(TARGET): $(OBJ)
+	$(CC) $(OBJ) $(LDFLAGS) -o $@
+
+# Compile source files into object files
+%.o: %.cpp
+	$(CC) $(CXXFLAGS) -c $< -o $@
+
+# Clean build files
+clean:
+	rm -f $(OBJ) $(TARGET)
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -8,3 +8,20 @@ See https://github.com/dwsJason/gslaplay, for a GSOS Sample Application
 that can play these animations
 
 
+## Mac Build instructions
+
+Requires xcode (g++/clang++).
+
+
+Debug build (default):
+```
+make
+```
+Release build:
+```
+make CONFIG=Release
+```
+Clean build artifacts:
+```
+make clean
+```

--- a/source/c2_file.cpp
+++ b/source/c2_file.cpp
@@ -61,7 +61,12 @@ void C2File::LoadFromFile(const char* pFilePath)
 	//--------------------------------------------------------------------------
 	// Read the file into memory
 	FILE* pFile = nullptr;
-	errno_t err = fopen_s(&pFile, pFilePath, "rb");
+#ifdef _WIN32
+    errno_t err = fopen_s(&pFile, pFilePath, "wb");
+#else
+    pFile = fopen(pFilePath, "rb");
+    errno_t err = (pFile == nullptr) ? errno : 0;
+#endif
 
 	if (0==err)
 	{

--- a/source/gsla_file.cpp
+++ b/source/gsla_file.cpp
@@ -1,4 +1,4 @@
-//
+// Also see: https://github.com/dwsJason/gslaplay for this documentation
 // C++ Encoder/Decoder
 // For GSLA, GS Lzb Animation File Format
 // 
@@ -6,7 +6,7 @@
 // Care is taken in the encoder, to make sure the 65816 does not have to cross
 // bank boundaries during any copy.  This is so we can use the MVN instruction,
 // and so we can reduce the number of bank checks in the code.  We will have an
-// opcode, that says “source data bank has changed”
+// opcode, that says 'source data bank has changed'
 // 
 // The file will be laid out such that you load the file in at a 64K memory
 // boundary
@@ -23,10 +23,10 @@
 //
 //File Offset			Data	Commentary
 //------------------------------------------------------------------
-//0				0x47	; ‘G’  Graphics
-//1				0x53	; ‘S’ 
-//2             0x4C    ; ‘L’  LZB
-//3				0x41    ; ‘A’  Animation
+//0				0x47	; 'G'  Graphics
+//1				0x53	; 'S' 
+//2				0x4C    ; 'L'  LZB
+//3				0x41    ; 'A'  Animation
 //
 // File Length, is the total length of the file
 //4				FileLengthLow    ; Low byte, 32-bit file length
@@ -43,7 +43,7 @@
 //					 ; R = 1, there is a ring frame
 //					 ; A Ring Frame is a frame that will delta from the last
 //                   ; frame of the animation, back to the first, for smoother
-//                   ; playback looping ,  If a ring frame exists, it’s also
+//                   ; playback looping ,  If a ring frame exists, it's also
 // 					 ; included in the frame count
 //
 // next is a word, width in bytes (likely 160 for now)
@@ -53,7 +53,7 @@
 // next is a word, height (likely 200 for now)
 //0xC				HL	    ; Display Height in bytes, low byte
 //0xD				HH      ; Display Height in bytes, high byte
-// 2 bytes, Frame Size in Bytes, since a “Frame” may contain more than just the
+// 2 bytes, Frame Size in Bytes, since a 'Frame' may contain more than just the
 // width * height, worth of pixels, for now this is $8000, or 32768
 //0xE				FBL     ; Frame Buffer Length Low
 //0xF				FBH     ; Frame Buffer Length High
@@ -67,34 +67,34 @@
 //
 // After this comes AIFF style chunks of data,  basically a 4 byte chunk name,
 // followed by a 4 byte length (inclusive of the chunk size).   The idea is that
-// you can skip chunks you don’t understand.
+// you can skip chunks you don't understand.
 //
 //File Offset:
 //0x14				First Chunk  (followed by more Chunks, until end of file)
 //
 //Chunk Definitions
-//Name:  ‘INIT’   -  Initial Frame Chunk, this is the data used to first initialize the playback buffer
-//0:	0x49	‘I’
-//1: 	0x4E	‘N’
-//2: 	0x49	‘I’
-//3: 	0x54	‘T’
+//Name:  'INIT'   -  Initial Frame Chunk, this is the data used to first initialize the playback buffer
+//0:	0x49	'I'
+//1: 	0x4E	'N'
+//2: 	0x49	'I'
+//3: 	0x54	'T'
 // 32 bit long, length, little endian, including the 8 byte header
 //4:	length low low
 //5:	length low high
 //6:	length high low
 //7:	length high high
 //
-//8: ….   This is a single frame of data, that decodes/decompresses into frame
+//8: ...   This is a single frame of data, that decodes/decompresses into frame
 //        sized bytes (right now 0x8000)
 // This data stream includes, an end of animation opcode, so that the normal
 // animation decompressor, can be called on this data, and it will emit the
 // initial frame onto the screen
 //
-//Name: ‘ANIM’ - Frames
-//0:	0x41 ‘A’
-//1:	0x4E ‘N’
-//2:	0x49 ‘I’
-//3:	0x4D ‘M’
+//Name: 'ANIM' - Frames
+//0:	0x41 'A'
+//1:	0x4E 'N'
+//2:	0x49 'I'
+//3:	0x4D 'M'
 // 32 bit long, length, little endian, including chunk header
 //4:	length low low
 //5:	length low high
@@ -103,7 +103,7 @@
 //
 // This is followed by the frames, with the intention of decompressing them at
 // 60FPS, which is why no play speed is included, if you need a play-rate
-// slower than this, blank frame’s should be inserted into the animation data
+// slower than this, blank frame's should be inserted into the animation data
 //
 // Every attempt is made to delta encode the image,  meaning we just encode
 // information about what changed each frame.   We attempt to make the size
@@ -189,7 +189,12 @@ void GSLAFile::LoadFromFile(const char* pFilePath)
 	//--------------------------------------------------------------------------
 	// Read the file into memory
 	FILE* pFile = nullptr;
-	errno_t err = fopen_s(&pFile, pFilePath, "rb");
+#ifdef _WIN32
+    errno_t err = fopen_s(&pFile, pFilePath, "wb");
+#else
+    pFile = fopen(pFilePath, "rb");
+    errno_t err = (pFile == nullptr) ? errno : 0;
+#endif
 
 	if (0==err)
 	{
@@ -475,7 +480,12 @@ void GSLAFile::SaveToFile(const char* pFilenamePath)
 	//--------------------------------------------------------------------------
 	// Create the file and write it
 	FILE* pFile = nullptr;
-	errno_t err = fopen_s(&pFile, pFilenamePath, "wb");
+#ifdef _WIN32
+    errno_t err = fopen_s(&pFile, pFilenamePath, "wb");
+#else
+    pFile = fopen(pFilenamePath, "rb");
+    errno_t err = (pFile == nullptr) ? errno : 0;
+#endif
 
 	if (0==err)
 	{


### PR DESCRIPTION
## MACOS Native Support
This adds support for Mac via the following changes:
- New `Makefile` for Mac
- I've added `#ifdefs` for now to just work around the `fopen_s` calls.  It's not super graceful, but we only have 3 places using it right now. 

## Build System
This adds automated builds such that:
- Every time you push _any_ branch to Github, it will build both Windows and Mac versions
- Every time you create a new tag like `v0.1.1` it will build *and* create a new release with downloadable artifaces